### PR TITLE
Fix use of extern in declarations

### DIFF
--- a/include/libfmapi.h.in
+++ b/include/libfmapi.h.in
@@ -312,49 +312,49 @@ int libfmapi_one_off_entry_identifier_get_utf16_email_address(
  * ------------------------------------------------------------------------- */
 
 LIBFMAPI_EXTERN \
-uint8_t libfmapi_class_identifier_mapi[ 16 ];
+extern uint8_t libfmapi_class_identifier_mapi[ 16 ];
 
 LIBFMAPI_EXTERN \
-uint8_t libfmapi_class_identifier_public_strings[ 16 ];
+extern uint8_t libfmapi_class_identifier_public_strings[ 16 ];
 
 LIBFMAPI_EXTERN \
-uint8_t libfmapi_class_identifier_internet_headers[ 16 ];
+extern uint8_t libfmapi_class_identifier_internet_headers[ 16 ];
 
 LIBFMAPI_EXTERN \
-uint8_t libfmapi_class_identifier_appointment[ 16 ];
+extern uint8_t libfmapi_class_identifier_appointment[ 16 ];
 
 LIBFMAPI_EXTERN \
-uint8_t libfmapi_class_identifier_task[ 16 ];
+extern uint8_t libfmapi_class_identifier_task[ 16 ];
 
 LIBFMAPI_EXTERN \
-uint8_t libfmapi_class_identifier_address[ 16 ];
+extern uint8_t libfmapi_class_identifier_address[ 16 ];
 
 LIBFMAPI_EXTERN \
-uint8_t libfmapi_class_identifier_common[ 16 ];
+extern uint8_t libfmapi_class_identifier_common[ 16 ];
 
 LIBFMAPI_EXTERN \
-uint8_t libfmapi_class_identifier_journal[ 16 ];
+extern uint8_t libfmapi_class_identifier_journal[ 16 ];
 
 LIBFMAPI_EXTERN \
-uint8_t libfmapi_class_identifier_sticky_note[ 16 ];
+extern uint8_t libfmapi_class_identifier_sticky_note[ 16 ];
 
 LIBFMAPI_EXTERN \
-uint8_t libfmapi_class_identifier_sharing[ 16 ];
+extern uint8_t libfmapi_class_identifier_sharing[ 16 ];
 
 LIBFMAPI_EXTERN \
-uint8_t libfmapi_class_identifier_rss_feed[ 16 ];
+extern uint8_t libfmapi_class_identifier_rss_feed[ 16 ];
 
 LIBFMAPI_EXTERN \
-uint8_t libfmapi_class_identifier_unified_messaging[ 16 ];
+extern uint8_t libfmapi_class_identifier_unified_messaging[ 16 ];
 
 LIBFMAPI_EXTERN \
-uint8_t libfmapi_class_identifier_calendar[ 16 ];
+extern uint8_t libfmapi_class_identifier_calendar[ 16 ];
 
 LIBFMAPI_EXTERN \
-uint8_t libfmapi_class_identifier_air_sync[ 16 ];
+extern uint8_t libfmapi_class_identifier_air_sync[ 16 ];
 
 LIBFMAPI_EXTERN \
-uint8_t libfmapi_class_identifier_attachment[ 16 ];
+extern uint8_t libfmapi_class_identifier_attachment[ 16 ];
 
 /* -------------------------------------------------------------------------
  * LZFu (de)compression functions

--- a/include/libfmapi/extern.h
+++ b/include/libfmapi/extern.h
@@ -33,10 +33,10 @@
 #define LIBFMAPI_EXTERN __declspec(dllexport)
 
 #elif defined( LIBFMAPI_DLL_IMPORT )
-#define LIBFMAPI_EXTERN extern __declspec(dllimport)
+#define LIBFMAPI_EXTERN __declspec(dllimport)
 
 #else
-#define LIBFMAPI_EXTERN extern
+#define LIBFMAPI_EXTERN
 
 #endif
 

--- a/libfmapi/libfmapi_checksum.h
+++ b/libfmapi/libfmapi_checksum.h
@@ -33,10 +33,10 @@ extern "C" {
 #endif
 
 LIBFMAPI_EXTERN_VARIABLE \
-uint32_t libfmapi_checksum_crc32_table[ 256 ];
+extern uint32_t libfmapi_checksum_crc32_table[ 256 ];
 
 LIBFMAPI_EXTERN_VARIABLE \
-int libfmapi_checksum_crc32_table_computed;
+extern int libfmapi_checksum_crc32_table_computed;
 
 void libfmapi_checksum_initialize_crc32_table(
       int );

--- a/libfmapi/libfmapi_class_identifier.h
+++ b/libfmapi/libfmapi_class_identifier.h
@@ -52,52 +52,52 @@ struct libfmapi_class_identifier_definition
 #endif /* defined( HAVE_DEBUG_OUTPUT ) */
 
 LIBFMAPI_EXTERN_VARIABLE \
-uint8_t libfmapi_class_identifier_mapi[ 16 ];
+extern uint8_t libfmapi_class_identifier_mapi[ 16 ];
 
 LIBFMAPI_EXTERN_VARIABLE \
-uint8_t libfmapi_class_identifier_public_strings[ 16 ];
+extern uint8_t libfmapi_class_identifier_public_strings[ 16 ];
 
 LIBFMAPI_EXTERN_VARIABLE \
-uint8_t libfmapi_class_identifier_internet_headers[ 16 ];
+extern uint8_t libfmapi_class_identifier_internet_headers[ 16 ];
 
 LIBFMAPI_EXTERN_VARIABLE \
-uint8_t libfmapi_class_identifier_appointment[ 16 ];
+extern uint8_t libfmapi_class_identifier_appointment[ 16 ];
 
 LIBFMAPI_EXTERN_VARIABLE \
-uint8_t libfmapi_class_identifier_task[ 16 ];
+extern uint8_t libfmapi_class_identifier_task[ 16 ];
 
 LIBFMAPI_EXTERN_VARIABLE \
-uint8_t libfmapi_class_identifier_address[ 16 ];
+extern uint8_t libfmapi_class_identifier_address[ 16 ];
 
 LIBFMAPI_EXTERN_VARIABLE \
-uint8_t libfmapi_class_identifier_common[ 16 ];
+extern uint8_t libfmapi_class_identifier_common[ 16 ];
 
 LIBFMAPI_EXTERN_VARIABLE \
-uint8_t libfmapi_class_identifier_journal[ 16 ];
+extern uint8_t libfmapi_class_identifier_journal[ 16 ];
 
 LIBFMAPI_EXTERN_VARIABLE \
-uint8_t libfmapi_class_identifier_sticky_note[ 16 ];
+extern uint8_t libfmapi_class_identifier_sticky_note[ 16 ];
 
 LIBFMAPI_EXTERN_VARIABLE \
-uint8_t libfmapi_class_identifier_sharing[ 16 ];
+extern uint8_t libfmapi_class_identifier_sharing[ 16 ];
 
 LIBFMAPI_EXTERN_VARIABLE \
-uint8_t libfmapi_class_identifier_rss_feed[ 16 ];
+extern uint8_t libfmapi_class_identifier_rss_feed[ 16 ];
 
 LIBFMAPI_EXTERN_VARIABLE \
-uint8_t libfmapi_class_identifier_unified_messaging[ 16 ];
+extern uint8_t libfmapi_class_identifier_unified_messaging[ 16 ];
 
 LIBFMAPI_EXTERN_VARIABLE \
-uint8_t libfmapi_class_identifier_calendar[ 16 ];
+extern uint8_t libfmapi_class_identifier_calendar[ 16 ];
 
 LIBFMAPI_EXTERN_VARIABLE \
-uint8_t libfmapi_class_identifier_air_sync[ 16 ];
+extern uint8_t libfmapi_class_identifier_air_sync[ 16 ];
 
 LIBFMAPI_EXTERN_VARIABLE \
-uint8_t libfmapi_class_identifier_attachment[ 16 ];
+extern uint8_t libfmapi_class_identifier_attachment[ 16 ];
 
 LIBFMAPI_EXTERN_VARIABLE \
-uint8_t libfmapi_class_identifier_unknown[ 16 ];
+extern uint8_t libfmapi_class_identifier_unknown[ 16 ];
 
 #if defined( HAVE_DEBUG_OUTPUT )
 

--- a/libfmapi/libfmapi_extern.h
+++ b/libfmapi/libfmapi_extern.h
@@ -30,15 +30,11 @@
 
 #include <libfmapi/extern.h>
 
-#if defined( __CYGWIN__ ) || defined( __MINGW32__ )
-#define LIBFMAPI_EXTERN_VARIABLE	extern
-#else
 #define LIBFMAPI_EXTERN_VARIABLE	LIBFMAPI_EXTERN
-#endif
 
 #else
-#define LIBFMAPI_EXTERN		/* extern */
-#define LIBFMAPI_EXTERN_VARIABLE	extern
+#define LIBFMAPI_EXTERN
+#define LIBFMAPI_EXTERN_VARIABLE
 
 #endif /* !defined( HAVE_LOCAL_LIBFMAPI ) */
 


### PR DESCRIPTION
Declare global variables to be extern (because they must be). Do not declare functions to be extern (because they are by default).